### PR TITLE
BOJ/11726/2*N 타일

### DIFF
--- a/baekjoon/11726.cpp
+++ b/baekjoon/11726.cpp
@@ -1,0 +1,34 @@
+/**
+ * @file 11726.cpp
+ * @author jang jeongwhan (you@domain.com)
+ * @brief 2*N 크기의 타일 채우기
+ * @version 0.1
+ * @date 2024-03-22
+ * 
+ * @copyright Copyright (c) 2024
+ * 
+ */
+
+#include<iostream>
+#include<vector>
+
+using namespace std;
+
+vector<int> dp(1000,0);
+int N;
+
+int main(void){
+    cin.tie(NULL);
+    ios_base::sync_with_stdio(false);
+    freopen("./input_file/11726.txt","rt",stdin);
+
+    cin>>N;
+    dp[1]=1;
+    dp[2]=2;
+
+    for(int i=3;i<=N;i++)
+        dp[i] = (dp[i-1] + dp[i-2])%10007;
+
+    cout<<dp[N];
+    return 0;
+}


### PR DESCRIPTION
BOJ/11726/2*N 타일

[[11726번: 2×n 타일링](https://www.acmicpc.net/problem/11726)](https://www.acmicpc.net/problem/11726)

### 문제설명

N이 주어졌을 때, 1*2, 2*1 타일로 만들수있는 패턴을 10007로 나눈나머지를 구하시오.

### 문제조건

![Untitled](https://prod-files-secure.s3.us-west-2.amazonaws.com/13092794-619e-423b-828c-ce5075dbf19e/66e9d4a7-ca70-4b29-af90-aaa5bec5802f/Untitled.png)

### 문제풀이

![Untitled](https://prod-files-secure.s3.us-west-2.amazonaws.com/13092794-619e-423b-828c-ce5075dbf19e/a2ddf112-d3b6-4cf0-a648-8494b6122590/Untitled.png)

1칸일 때 가능한 조합 1개

2칸일 때 가능한 조합 2개

3칸일 때 가능한 조합  f(2) * f(1) + f(1) * f(1)= 3 개

4칸일 때 가능한 조합 f(3)* f(1) + f(2) *f(1)= 5개

5칸일 때 가능한 조합 f(4) * f(1) + f(3) *f(1) = 8개

- N칸일때 가능한 조합은
    - 2*1크기의 블록한개를 먼저채워넣고 N-1개를 채우는 조합과 2*2조합중 1*2, 1*2블록 두개를 먼저 채워넣고 N-2개를 채우는 조합을 더하면된다.

### code

```jsx
/**
 * @file 11726.cpp
 * @author jang jeongwhan (you@domain.com)
 * @brief 2*N 크기의 타일 채우기
 * @version 0.1
 * @date 2024-03-22
 * 
 * @copyright Copyright (c) 2024
 * 
 */

#include<iostream>
#include<vector>

using namespace std;

vector<int> dp(1000,0);
int N;

int main(void){
    cin.tie(NULL);
    ios_base::sync_with_stdio(false);
    freopen("./input_file/11726.txt","rt",stdin);

    cin>>N;
    dp[1]=1;
    dp[2]=2;

    for(int i=3;i<=N;i++)
        dp[i] = (dp[i-1] + dp[i-2])%10007;

    cout<<dp[N];
    return 0;
}
```