### PR TITLE
BOJ/ATM/11399/2020KB/0ms

### DIFF
--- a/baekjoon/11399.cpp
+++ b/baekjoon/11399.cpp
@@ -1,0 +1,41 @@
+/**
+ * @file 11399.cpp
+ * @author jang jeonghwan (you@domain.com)
+ * @brief BOJ/ATM/11399
+ * @version 0.1
+ * @date 2024-05-20
+ * 
+ * @copyright Copyright (c) 2024
+ * 
+ */
+
+#include<iostream>
+#include<vector>
+#include<algorithm>
+
+using namespace std;
+int N;
+vector<int> people;
+
+int main(void){
+    cin.tie(NULL);
+    ios_base::sync_with_stdio(false);
+    freopen("./input_file/11399.txt","rt",stdin);
+    
+    int tmp=0,acc=0,res=0;
+
+    cin>>N;
+    for(int i=0;i<N;i++){
+        cin>>tmp;
+        people.push_back(tmp);
+    }
+    sort(people.begin(),people.end());
+
+    for(int i=0;i<N;i++){
+        acc+=people[i];
+        res+=acc;
+    }
+    cout<<res;
+
+    return 0;
+}


### PR DESCRIPTION
## 11399 ATM

[](https://www.acmicpc.net/problem/11399)

### 문제설명

- N명의 사람이 있고 각자 돈을 뽑을때 걸리는 시간이 다를 수 있다.
- 이때 N명의 사람들 모두 돈을 뽑는데 걸리는 최소 시간을 구하시오.
- 돈을 인출하는데 걸리는 시간이라는 뜻은 앞의 사람들이 돈을 뽑는동안 기다리는 시간도 포함.

### 문제조건

- 시간제한 1s
- 메모리제한 256MB
- 1≤N≤1000
- 1≤돈을 뽑는데 걸리는시간≤1000

### 문제풀이

- 돈을 뽑는데 걸리는 시간이 가장 적은 사람먼저 인출을 하면 끝.

### CODE

```cpp
/**
 * @file 11399.cpp
 * @author jang jeonghwan (you@domain.com)
 * @brief BOJ/ATM/11399
 * @version 0.1
 * @date 2024-05-20
 * 
 * @copyright Copyright (c) 2024
 * 
 */

#include<iostream>
#include<vector>
#include<algorithm>

using namespace std;
int N;
vector<int> people;

int main(void){
    cin.tie(NULL);
    ios_base::sync_with_stdio(false);
    freopen("./input_file/11399.txt","rt",stdin);
    
    int tmp=0,acc=0,res=0;

    cin>>N;
    for(int i=0;i<N;i++){
        cin>>tmp;
        people.push_back(tmp);
    }
    sort(people.begin(),people.end());

    for(int i=0;i<N;i++){
        acc+=people[i];
        res+=acc;
    }
    cout<<res;

    return 0;
}
```