### PR TITLE
BOJ/1074/Z/2208KB/0ms

### DIFF
--- a/baekjoon/1074.cpp
+++ b/baekjoon/1074.cpp
@@ -1,0 +1,35 @@
+/**
+ * @file 1074.cpp
+ * @author jang jeonghwan (you@domain.com)
+ * @brief  BOJ/Z
+ * @version 0.1
+ * @date 2024-06-27
+ * 
+ * @copyright Copyright (c) 2024
+ * 
+ */
+
+#include<iostream>
+#include<cmath>
+
+using namespace std;
+
+int main(void){
+    int N,r,c;
+
+    cin>>N>>r>>c;
+    int expo=N,sum=0,base=2,remainR=0,remainC=0;
+
+    while(r!=0 || c!=0){
+        int x=0,y=0;
+        int line= pow(base,expo-1);
+        if(r>=line) {y=1; r-=line;}
+        if(c>=line) {x=1; c-=line;}
+        sum+=pow(base,2*(expo-1))*(x+2*y);
+        expo--; 
+    }
+
+    cout<<sum;
+    
+    return 0;
+}


### PR DESCRIPTION
## BOJ/1074/Z/2208KB/0ms

[](https://www.acmicpc.net/problem/1074)

### 문제설명

- N,r,c가  주어지면 다음과 같은 2^N * 2^N의 map이 주어진다. 위와같이 2차원인 map을 Z모양으로 탐색할때
- (c,r)에 해당하는 좌표의 값은 얼마인지 구하여라
- 
<img width="262" alt="image" src="https://github.com/jjhwan-h/algorithm/assets/92563695/4ee8a88a-ea4f-40fc-bed2-5a8470032217">


### 문제조건

- 시간제한 0.5s, 메모리제한 512GB
- 1 ≤ N ≤ 15
- 0 ≤ r, c < 2^N

### 문제풀이

- N이 최대 15이고 시간제한이 0.5s이므로 2^15*2^15를 하나하나 탐색하는 것은 시간초과가 발생한다.
- 따라서 큰부분에서 작은부분으로 분할정복하며 점화식을 찾아낸다.

```cpp
N=1일 때 
0 1
2 3

N=2일 때
0 1 4 5
2 3 6 7
8 9 12 13
10 11 14 15

...

N=1일 때 
(0,0)인경우 0, (0,1)인경우 1
(1,0)인경우 2, (1,1)인경우 3이므로 이에 따른 점화식을 세우면
x+2y이다.

N=2일 때 [0,1,2,3],[4,5,6,7],[8,9,10,11],[12,13,14,15]를 묶음으로
0 1
2 3으로 나누면 점화식은 2^2*x + 2^3*y이다.
...
따라서 N에 따른 점화식은 **2^{2(N-1)} * (x+2y)**이다.

N부터 차근차근 범위를 4개로 나누고 이 범위를 좁혀가며 위치를 파악한다.

sum변수를 두어 N일때 4개의 범위로 나누어 어디에 속하는지 파악한 후 
위의 점화식을 통해 해당범위의 최소값을 sum에 더한다.
N을 1감소시키고 좌표도 해당 범위안에서의 r과c좌표로 수정 위의 과정을 반복한다.
```
<img width="263" alt="image" src="https://github.com/jjhwan-h/algorithm/assets/92563695/f10ff5bb-1a30-4ccc-b654-0f0dcd90de9a">

N=3일 때 r=6,c=7인 좌표를 찾아가는 과정

### CODE

```cpp
/**
 * @file 1074.cpp
 * @author jang jeonghwan (you@domain.com)
 * @brief  BOJ/Z
 * @version 0.1
 * @date 2024-06-27
 * 
 * @copyright Copyright (c) 2024
 * 
 */

#include<iostream>
#include<cmath>

using namespace std;

int main(void){
    int N,r,c;

    cin>>N>>r>>c;
    int expo=N,sum=0,base=2,remainR=0,remainC=0;

    while(r!=0 || c!=0){
        int x=0,y=0;
        int line= pow(base,expo-1);
        if(r>=line) {y=1; r-=line;}
        if(c>=line) {x=1; c-=line;}
        sum+=pow(base,2*(expo-1))*(x+2*y);
        expo--; 
    }

    cout<<sum;
    
    return 0;
}
```