### PR TITLE
BOJ/6588/골드바흐의 추측/5928KB/228ms

### DIFF
--- a/baekjoon/6588.cpp
+++ b/baekjoon/6588.cpp
@@ -1,0 +1,61 @@
+/**
+ * @file 6588.cpp
+ * @author jang jeonghwan (you@domain.com)
+ * @brief BOJ/골드바흐의 추측
+ * @version 0.1
+ * @date 2024-07-12
+ * 
+ * @copyright Copyright (c) 2024
+ * 
+ */
+
+#include<iostream>
+#include<vector>
+
+using namespace std;
+vector<int> prime(1000000);
+
+void calPrime(){
+    prime[2]=1;
+    prime[3]=1;
+    for(int i=4;i<=1000000;i++){
+        bool flag=false;
+        for(int j=2;j*j<=i;j++){
+            if(i%j==0) {flag=true; break;}
+        }
+        if(!flag) prime[i]=1;
+        else prime[i]=0;
+    }
+}
+
+void solve(){
+    int n;
+    calPrime();
+    while(true){
+        int pre=0,post=0;
+        cin>>n;
+        if(n==0) break;
+        
+        for(int i=3;i<=n/2;i+=2){
+            if(prime[i]&&prime[n-i]) {
+                pre=i;
+                post=n-i;
+                break;
+            }
+        }
+        if(pre && post){
+            cout<<n<<" = "<<pre<<" + "<<post<<"\n";
+        }else{
+            cout<<"Goldbach's conjecture is wrong."<<"\n";
+        }
+    }
+}
+int main(void){
+    cin.tie(NULL);
+    ios_base::sync_with_stdio(false);
+    freopen("./input_file/6588.txt","rt",stdin);
+
+    solve();
+
+    return 0;
+}


### PR DESCRIPTION
## BOJ/6588/골드바흐의 추측/5928KB/228ms

(https://www.acmicpc.net/problem/6588)

### 문제설명

```cpp
4보다 큰 모든 짝수는 두 홀수 소수의 합으로 나타낼 수 있다.
```

- 1,000,000이하의 수에 대하여 위의 명제를 검증하는 프로그램을 작성하시오.

### 문제조건

- 테스트케이스의 개수는 100,000개 이하
- 각 테스트 케이스는 짝수 정수 n하나로 이루어짐
- 각 테스트 케이스에 대하여 n = a + b형태로 출력
- 만약 방법이 여러가지라면 b-a가 가장 큰것을 출력
- 두 홀수 소수의 합으로 n을 나타낼 수 없는 경우 "Goldbach's conjecture is wrong."을 출력
- 시간제한 :0.5s, 메모리제한: 256MB

### 문제풀이

- 에라토스테네스의 체로 1,000,000이하의 소수 배열을 먼저 구한다.
- 홀수 소수로 이루어진 값으로 n을 나타낼 수 있는지 확인하는 것,
    - n을 나타내기위한 최대 정수의 합은 n/2+n/2이므로 n/2까지만 확인하면 된다.
    - 따라서 반복문은 for(int i=3;i≤n/2;i+=2)

### CODE

```cpp
/**
 * @file 6588.cpp
 * @author jang jeonghwan (you@domain.com)
 * @brief BOJ/골드바흐의 추측
 * @version 0.1
 * @date 2024-07-12
 * 
 * @copyright Copyright (c) 2024
 * 
 */

#include<iostream>
#include<vector>

using namespace std;
vector<int> prime(1000000);

void calPrime(){
    prime[2]=1;
    prime[3]=1;
    for(int i=4;i<=1000000;i++){
        bool flag=false;
        for(int j=2;j*j<=i;j++){
            if(i%j==0) {flag=true; break;}
        }
        if(!flag) prime[i]=1;
        else prime[i]=0;
    }
}

void solve(){
    int n;
    calPrime();
    while(true){
        int pre=0,post=0;
        cin>>n;
        if(n==0) break;
        
        for(int i=3;i<=n/2;i+=2){
            if(prime[i]&&prime[n-i]) {
                pre=i;
                post=n-i;
                break;
            }
        }
        if(pre && post){
            cout<<n<<" = "<<pre<<" + "<<post<<"\n";
        }else{
            cout<<"Goldbach's conjecture is wrong."<<"\n";
        }
    }
}
int main(void){
    cin.tie(NULL);
    ios_base::sync_with_stdio(false);
    freopen("./input_file/6588.txt","rt",stdin);

    solve();

    return 0;
}
```