### PR TITLE
BOJ/1012/유기농 배추/1488KB/8ms

### DIFF
--- a/GO/1012/1012.go
+++ b/GO/1012/1012.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+var reader *bufio.Reader
+var writer = bufio.NewWriter(os.Stdout)
+var N, M, K int
+var area [51][51]int
+
+type cabbage struct {
+	x, y int
+}
+
+func initArea() {
+	for i := 0; i < 51; i++ {
+		for j := 0; j < 51; j++ {
+			area[i][j] = 0
+		}
+	}
+}
+
+func bfs(cabbages []cabbage) (res int) {
+	dirs := [][2]int{{0, 1}, {0, -1}, {1, 0}, {-1, 0}}
+	visited := [51][51]int{}
+
+	for _, v := range cabbages {
+		if visited[v.y][v.x] == 1 {
+			continue
+		}
+		queue := [][2]int{{v.y, v.x}}
+		for len(queue) > 0 {
+			el := queue[0]
+			queue = queue[1:]
+			for _, dir := range dirs {
+				nx, ny := el[1]+dir[1], el[0]+dir[0]
+				if nx >= 0 && nx < M && ny >= 0 && ny < N && visited[ny][nx] == 0 && area[ny][nx] == 1 {
+					visited[ny][nx] = 1
+					queue = append(queue, [2]int{ny, nx})
+				}
+			}
+		}
+		res++
+	}
+	initArea()
+	return
+}
+
+func input() (cabbages []cabbage) {
+	var x, y int
+	fmt.Fscan(reader, &M, &N, &K)
+	for j := 0; j < K; j++ {
+		fmt.Fscan(reader, &x, &y)
+		cabbages = append(cabbages, cabbage{x, y})
+		area[y][x] = 1
+	}
+	return
+}
+func solve() {
+	defer writer.Flush()
+
+	var T int
+	fmt.Fscan(reader, &T)
+	for i := 0; i < T; i++ {
+		cabbages := input()
+		res := bfs(cabbages)
+		fmt.Fprintf(writer, "%d\n", res)
+	}
+}
+func main() {
+	// file, err := os.Open("./1012.txt")
+	// if err != nil {
+	// 	fmt.Println("can'not open file", err)
+	// }
+	// defer file.Close()
+	reader = bufio.NewReader(os.Stdin)
+	solve()
+}


### PR DESCRIPTION
## BOJ/1012/유기농 배추/1488KB/8ms

(https://www.acmicpc.net/problem/1012)

### 문제 설명

- 상하좌우로 붙어있는 양배추들에는 하나의 애벌래를 두어 자연농법을 할 수가 있다.
- 총 T번의 테스트케이스와 각 테스트케이스별 양배추의 좌표들이 주어질때, 최소 몇마리의 애벌래를 두어야하는지 구하시오.

### 문제 조건

- 배추밭의 크기 , 가로 (1≤M≤50)  세로 (1≤N≤50)
- 배추가 심어져있는 좌표 개수 K(1≤K≤2500)
- 시간제한:1s , 메모리제한:512MB

### 문제 풀이

- BFS를 이용해 양배추 그룹이 몇개인지 count
- 단, 매 테스트케이스마다 area는 초기화 해주어야한다.
- queue는 이차원 슬라이스로 단순히 구현

### CODE

```jsx
package main

import (
	"bufio"
	"fmt"
	"os"
)

var reader *bufio.Reader
var writer = bufio.NewWriter(os.Stdout)
var N, M, K int
var area [51][51]int

type cabbage struct {
	x, y int
}

func initArea() {
	for i := 0; i < 51; i++ {
		for j := 0; j < 51; j++ {
			area[i][j] = 0
		}
	}
}

func bfs(cabbages []cabbage) (res int) {
	dirs := [][2]int{{0, 1}, {0, -1}, {1, 0}, {-1, 0}}
	visited := [51][51]int{}

	for _, v := range cabbages {
		if visited[v.y][v.x] == 1 {
			continue
		}
		queue := [][2]int{{v.y, v.x}}
		for len(queue) > 0 {
			el := queue[0]
			queue = queue[1:]
			for _, dir := range dirs {
				nx, ny := el[1]+dir[1], el[0]+dir[0]
				if nx >= 0 && nx < M && ny >= 0 && ny < N && visited[ny][nx] == 0 && area[ny][nx] == 1 {
					visited[ny][nx] = 1
					queue = append(queue, [2]int{ny, nx})
				}
			}
		}
		res++
	}
	initArea()
	return
}

func input() (cabbages []cabbage) {
	var x, y int
	fmt.Fscan(reader, &M, &N, &K)
	for j := 0; j < K; j++ {
		fmt.Fscan(reader, &x, &y)
		cabbages = append(cabbages, cabbage{x, y})
		area[y][x] = 1
	}
	return
}
func solve() {
	defer writer.Flush()

	var T int
	fmt.Fscan(reader, &T)
	for i := 0; i < T; i++ {
		cabbages := input()
		res := bfs(cabbages)
		fmt.Fprintf(writer, "%d\n", res)
	}
}
func main() {
	// file, err := os.Open("./1012.txt")
	// if err != nil {
	// 	fmt.Println("can'not open file", err)
	// }
	// defer file.Close()
	reader = bufio.NewReader(os.Stdin)
	solve()
}

```