### PR TITLE
BOJ/11724/연결 요소의 개수/4192KB/292ms

### DIFF
--- a/GO/11724/11724.go
+++ b/GO/11724/11724.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+var reader *bufio.Reader
+var writer = bufio.NewWriter(os.Stdout)
+var unf = make([]int, 1001)
+var res = make([]int, 1001)
+
+func FIND(a int) int {
+	if a == unf[a] {
+		return a
+	}
+	unf[a] = FIND(unf[a])
+	return unf[a]
+}
+func UNION(a, b int) {
+	fa := FIND(a)
+	fb := FIND(b)
+	if fa != fb {
+		unf[fa] = fb
+	}
+}
+func main() {
+	var cnt int
+	defer writer.Flush()
+
+	// file, err := os.Open("./11724.txt")
+	// if err != nil {
+	// 	fmt.Println("can'not open file", err)
+	// }
+	// defer file.Close()
+
+	reader = bufio.NewReader(os.Stdin)
+
+	var N, M, s, e int
+	fmt.Fscan(reader, &N, &M)
+
+	for i := 1; i <= N; i++ {
+		unf[i] = i
+	}
+	for i := 0; i < M; i++ {
+		fmt.Fscan(reader, &s, &e)
+		UNION(s, e)
+	}
+	for i := 1; i <= N; i++ {
+		if res[FIND(i)] == 0 {
+			cnt++
+			res[FIND(i)] = res[FIND(i)] + 1
+		}
+	}
+	fmt.Fprint(writer, cnt)
+}


### PR DESCRIPTION
(https://www.acmicpc.net/problem/11724)

### 문제 설명

- 무방향 그래프가 주어졌을 때, 연결요소의 개수를 구하시오.

### 문제 조건

- 정점의 개수 1≤N≤1000, 간선의 개수 0 ≤ M ≤ N×(N-1)/2

### 문제 풀이

- 두개의 정점이 여러개 주어졌을때 이를 연결하여 그래프를 만들고
- 몇개의  그래프가 생성되는 지 출력하는 문제
- UNION&FIND로 그룹을 지어 해결할 수 있다.
- FIND로 각 그룹이 어느 그룹에 속해있는지 확인하고 효율을 높이기 위해 확인하면서 값을 갱신
- FIND로 확인된 그룹을 UNION으로 묶어준다.

### CODE

```go
package main

import (
	"bufio"
	"fmt"
	"os"
)

var reader *bufio.Reader
var writer = bufio.NewWriter(os.Stdout)
var unf = make([]int, 1001)
var res = make([]int, 1001)

func FIND(a int) int {
	if a == unf[a] {
		return a
	}
	unf[a] = FIND(unf[a])
	return unf[a]
}
func UNION(a, b int) {
	fa := FIND(a)
	fb := FIND(b)
	if fa != fb {
		unf[fa] = fb
	}
}

func main() {
	var cnt int
	defer writer.Flush()

	reader = bufio.NewReader(os.Stdin)

	var N, M, s, e int
	fmt.Fscan(reader, &N, &M)

	for i := 1; i <= N; i++ {
		unf[i] = i
	}
	for i := 0; i < M; i++ {
		fmt.Fscan(reader, &s, &e)
		UNION(s, e)
	}
	for i := 1; i <= N; i++ {
		if res[FIND(i)] == 0 {
			cnt++
			res[FIND(i)] = res[FIND(i)] + 1
		}
	}
	fmt.Fprint(writer, cnt)
}

```

