### PR TITLE
BOJ/1991/트리순회/884KB/4ms

### DIFF
--- a/GO/1991/1991.go
+++ b/GO/1991/1991.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+type node struct {
+	n  rune
+	lc rune
+	rc rune
+}
+type nodeSlice []node
+
+var nodes = make(nodeSlice, 27)
+var reader *bufio.Reader
+var writer = bufio.NewWriter(os.Stdout)
+
+func input() {
+	var num int
+	var n, l, r rune
+	fmt.Fscanf(reader, "%d\n", &num)
+
+	for i := 0; i < num; i++ {
+		fmt.Fscanf(reader, "%c %c %c\n", &n, &l, &r)
+		nodes[int(n)-'A'] = node{n, l, r}
+	}
+}
+func (p nodeSlice) prefix(idx int) {
+	if idx < 0 {
+		return
+	}
+	fmt.Fprintf(writer, "%c", p[idx].n)
+	p.prefix(int(p[idx].lc) - 'A')
+	p.prefix(int(p[idx].rc) - 'A')
+}
+func (p nodeSlice) postfix(idx int) {
+	if idx < 0 {
+		return
+	}
+	p.postfix(int(p[idx].lc) - 'A')
+	p.postfix(int(p[idx].rc) - 'A')
+	fmt.Fprintf(writer, "%c", p[idx].n)
+}
+func (p nodeSlice) infix(idx int) {
+	if idx < 0 {
+		return
+	}
+	p.infix(int(p[idx].lc) - 'A')
+	fmt.Fprintf(writer, "%c", p[idx].n)
+	p.infix(int(p[idx].rc) - 'A')
+}
+func solve() {
+	nodes.prefix(0)
+	fmt.Fprint(writer, "\n")
+	nodes.infix(0)
+	fmt.Fprint(writer, "\n")
+	nodes.postfix(0)
+}
+func main() {
+	defer writer.Flush()
+
+	// file, err := os.Open("./1991.txt")
+	// if err != nil {
+	// 	fmt.Println("can'not open file", err)
+	// }
+	// defer file.Close()
+	reader = bufio.NewReader(os.Stdin)
+
+	input()
+	solve()
+}


### PR DESCRIPTION
(https://www.acmicpc.net/problem/1991)

### 문제 설명

```go
7
A B C
B D .
C E F
E . .
F . G
D . .
G . .
```

- 다음과 같은 입력이 주어졌을 때, 전위, 중위, 후위 순회를 하시오.
- 처음 숫자는 N으로 노드의 개수
- 그다음 노드의 개수만큼 (노드의 문자, 왼쪽 자식, 오른쪽 자식)이 주어진다.
- 자식이 없는 경우는 ‘ . ’ 으로 나타낸다.

### 문제 조건

- 노드의 개수 N(1 ≤ N ≤ 26) ⇒ 알파벳 수만틈 주어진다.
    - 각 노드의 문자는 알파벳으로 이루어진다.
    - A가 항상 루트노드
- 시간제한: 2s, 메모리제한: 128MB

### 문제 풀이

- 최대 노드의 개수가 알파벳과 동일하므로 slie를 두고 index로는 [문자] - ‘A’로 지정
    - A=0, B=1, C=2…
- go에는 char자료형이 없으므로 rune자료형으로 입력을 받는다.
- index를 계산할때는 rune을 int로 변환 후 - ‘A’
    - rune은 int32값이지만 완전히 다른 값으로 인식하기 때문에 직접적인 비교연산은 수행불가함
- fscnaf로 rune을 입력받을 때 개행인 경우 \n을 붙여준다.

### CODE

```go
package main

import (
	"bufio"
	"fmt"
	"os"
)

type node struct {
	n  rune
	lc rune
	rc rune
}
type nodeSlice []node

var nodes = make(nodeSlice, 27)
var reader *bufio.Reader
var writer = bufio.NewWriter(os.Stdout)

func input() {
	var num int
	var n, l, r rune
	fmt.Fscanf(reader, "%d\n", &num)

	for i := 0; i < num; i++ {
		fmt.Fscanf(reader, "%c %c %c\n", &n, &l, &r)
		nodes[int(n)-'A'] = node{n, l, r}
	}
}
func (p nodeSlice) prefix(idx int) {
	if idx < 0 {
		return
	}
	fmt.Fprintf(writer, "%c", p[idx].n)
	p.prefix(int(p[idx].lc) - 'A')
	p.prefix(int(p[idx].rc) - 'A')
}
func (p nodeSlice) postfix(idx int) {
	if idx < 0 {
		return
	}
	p.postfix(int(p[idx].lc) - 'A')
	p.postfix(int(p[idx].rc) - 'A')
	fmt.Fprintf(writer, "%c", p[idx].n)
}
func (p nodeSlice) infix(idx int) {
	if idx < 0 {
		return
	}
	p.infix(int(p[idx].lc) - 'A')
	fmt.Fprintf(writer, "%c", p[idx].n)
	p.infix(int(p[idx].rc) - 'A')
}
func solve() {
	nodes.prefix(0)
	fmt.Fprint(writer, "\n")
	nodes.infix(0)
	fmt.Fprint(writer, "\n")
	nodes.postfix(0)
}
func main() {
	defer writer.Flush()

	reader = bufio.NewReader(os.Stdin)

	input()
	solve()
}

```