### PR TITLE
BOJ/1697/보물찾기/5112KB/8ms

### DIFF
--- a/GO/1697/1697.go
+++ b/GO/1697/1697.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+var reader *bufio.Reader
+var writer = bufio.NewWriter(os.Stdout)
+var N, K int
+var arr = make([]int, 100001)
+var d = [3]int{1, -1, 2}
+
+func main() {
+	defer writer.Flush()
+	reader = bufio.NewReader(os.Stdin)
+	fmt.Fscan(reader, &N, &K)
+
+	for i := range arr {
+		arr[i] = 100001
+	}
+
+	que := []int{N}
+	arr[N] = 0
+	for len(que) > 0 {
+		el := que[0]
+		que = que[1:]
+
+		for i := 0; i < 3; i++ {
+			var nd int
+			if i == 2 {
+				nd = el * d[i]
+			} else {
+				nd = el + d[i]
+			}
+
+			if nd >= 0 && nd <= 100000 && arr[el]+1 < arr[nd] {
+				arr[nd] = arr[el] + 1
+				que = append(que, nd)
+			}
+		}
+	}
+	fmt.Fprint(writer, arr[K])
+}


### PR DESCRIPTION
(https://www.acmicpc.net/problem/1697)

### 문제 설명

- 수빈이의 위치와 동생의 위치가 직선상에 위치할때, 수빈이의 위치에서 동생까지 몇회만에 도달 할 수있는지 구하여라.
- 수빈이는 1회에 자신의 위치에서 +1, -1, *2 할 수 있다.

### 문제 조건

- 수빈이의 위치 0≤N≤100000
- 동생의 위치 0≤K≤100000
- 시간제한: 2s, 메모리제한:128MB

### 문제 풀이

- 직선상의 배열을 최대값인 100001로 초기화
- 수빈이의 위치를 bfs한다.
    - 수빈이가 움직일 수 있는 경우는 +1,-1,*2
    - 만약 수빈이가 움직일 위치가 현재 수빈이의 위치+1보다 클경우는 현재 수빈이의 위치+1로 초기화 하고
    - 큐에 삽입

### CODE

```go
package main

import (
	"bufio"
	"fmt"
	"os"
)

var reader *bufio.Reader
var writer = bufio.NewWriter(os.Stdout)
var N, K int
var arr = make([]int, 100001)
var d = [3]int{1, -1, 2}

func main() {
	defer writer.Flush()
	reader = bufio.NewReader(os.Stdin)
	fmt.Fscan(reader, &N, &K)

	for i := range arr {
		arr[i] = 100001
	}

	que := []int{N}
	arr[N] = 0
	for len(que) > 0 {
		el := que[0]
		que = que[1:]

		for i := 0; i < 3; i++ {
			var nd int
			if i == 2 {
				nd = el * d[i]
			} else {
				nd = el + d[i]
			}

			if nd >= 0 && nd <= 100000 && arr[el]+1 < arr[nd] {
				arr[nd] = arr[el] + 1
				que = append(que, nd)
			}
		}
	}
	fmt.Fprint(writer, arr[K])
}

```