### PR TITLE
BOJ/3022/개똥벌래/9144KB/32ms

### DIFF
--- a/GO/3020/3020-1.go
+++ b/GO/3020/3020-1.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strconv"
+)
+
+var (
+	reader *bufio.Scanner
+	writer = bufio.NewWriter(os.Stdout)
+	N, H   int
+)
+
+type Obst struct {
+	top  [500001]int
+	down [500001]int
+}
+
+func setup() *Obst {
+	N, H = readInt(), readInt()
+	obst := &Obst{}
+	for i := 1; i <= N; i++ {
+		tmp := readInt()
+		if i%2 == 0 {
+			obst.top[H-tmp+1] += 1
+		} else {
+			obst.down[tmp] += 1
+		}
+	}
+
+	for j := H - 1; j >= 1; j-- {
+		obst.down[j] += obst.down[j+1]
+	}
+	return obst
+}
+
+func solve(obst *Obst) {
+	min, cnt := 200001, 0
+	for i := 1; i <= H; i++ {
+		obst.top[i] += obst.top[i-1]
+		res := obst.down[i] + obst.top[i]
+		if min > res {
+			min = res
+			cnt = 1
+		} else if min == res {
+			cnt++
+		}
+	}
+	fmt.Fprint(writer, min, cnt)
+}
+
+func main() {
+	defer writer.Flush()
+	f, _ := os.Open("./3020.txt")
+	defer f.Close()
+
+	reader = bufio.NewScanner(f)
+	reader.Split(bufio.ScanWords)
+
+	obst := setup()
+	solve(obst)
+}
+
+func parseInt(s string) int {
+	n, _ := strconv.Atoi(s)
+	return n
+}
+
+func readInt() int {
+	reader.Scan()
+	return parseInt(reader.Text())
+}

--- a/GO/3020/3020.go
+++ b/GO/3020/3020.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"sort"
+)
+
+type IO struct {
+	reader *bufio.Reader
+	writer *bufio.Writer
+}
+type Blocks struct {
+	top  []int
+	down []int
+}
+type Res struct {
+	min int
+	res int
+}
+
+var N, H int
+
+func input(io *IO) *Blocks {
+	var tmp int
+	blocks := &Blocks{}
+	fmt.Fscanf(io.reader, "%d %d", &N, &H)
+	for i := 1; i <= N; i++ {
+		fmt.Fscan(io.reader, &tmp)
+		if i%2 == 0 {
+			blocks.top = append(blocks.top, tmp)
+		} else {
+			blocks.down = append(blocks.down, tmp)
+		}
+	}
+	return blocks
+}
+
+func binarySearch(arr []int, t int) int {
+	l, r := 0, len(arr)-1
+	for l <= r {
+		m := l + (r-l)/2
+		if arr[m] >= t {
+			r = m - 1
+		} else {
+			l = m + 1
+		}
+	}
+	return l
+}
+
+func countBlocking(arr []int, i int) int {
+	idx := binarySearch(arr, i)
+	if idx != -1 {
+		return N/2 - idx
+	}
+	return 0
+}
+
+func solve(blocks *Blocks) *Res {
+	min, res := 200001, 1
+
+	sort.Slice(blocks.top, func(i, j int) bool {
+		return blocks.top[i] < blocks.top[j]
+	})
+	sort.Slice(blocks.down, func(i, j int) bool {
+		return blocks.down[i] < blocks.down[j]
+	})
+
+	for i := 1; i <= H; i++ {
+		var cnt int
+		cnt += countBlocking(blocks.down, i)
+		cnt += countBlocking(blocks.top, H-i+1)
+		if min > cnt {
+			min = cnt
+			res = 1
+		} else if min == cnt {
+			res++
+		}
+	}
+	return &Res{min, res}
+}
+
+func main() {
+	f, _ := os.Open("./3020.txt")
+	defer f.Close()
+	io := &IO{bufio.NewReader(f), bufio.NewWriter(os.Stdout)}
+	defer io.writer.Flush()
+	blocks := input(io)
+	res := solve(blocks)
+	fmt.Fprintf(io.writer, "%d %d", res.min, res.res)
+}


### PR DESCRIPTION
(https://www.acmicpc.net/problem/3020)

### 문제설명

길이 N미터 높이 H미터인 동굴안에서 개똥벌래가 장애물을 부수며 일직선으로 날아간다.

이때 개똥벌래가 부수는 장애물의 최소개수와 그러한 높이구간이 몇개있는지 구하는 프로그램을 작성하시오.

![image.png](https://prod-files-secure.s3.us-west-2.amazonaws.com/13092794-619e-423b-828c-ce5075dbf19e/7990dfb1-2eff-4f13-911d-69fe2565b358/image.png)

### 문제조건

 N은 항상 짝수이다. (2 ≤ N ≤ 200,000, 2 ≤ H ≤ 500,000)

시간제한:1s, 메모리제한 :128MB

### 문제풀이

단순히 생각하면 모든 높이 구간에 대하여 각 미터마다 존재하는 장애물이 부서지는 확인한다.

하지만 최대 200,000 * 500,000 = 100,000,000,000 ⇒천억이므로 무조건 시간제한에 걸린다.

따라서 두가지 방법으로 풀이 가능하다.

1. 이분탐색
2. 누적합 (더 효율적)

```go
1. 이분탐색

- 위에서 자라는 장애물(top), 아래에서 자라는 장애물(down)을 따로 슬라이스에 저장
- 각각 오름차순 정렬
- 모든 높이구간에 대하여 이분탐색을 top, down에 각각 수행한다.
- 이분탐색에서 리턴되는 값은 부서지는 장애물중 가장 큰 장애물의 좌표(idx)
- 따라서 N-idx를 하면 개똥벌래가 해당 높이구간을 지나갈때 부서지는 장애물의 좌표개수가 나온다.
```

```go
2. 누적합
누적합은 말그대로 이전 원소값을 다음 원소값에 계속 더해서 저장하는 구조
이를 이용해서 H크기 만큼의 슬라이스를 두었을때, 각 원소의 인덱스는 장애물의 높이이고 원소의 값은
해당 높이의 장애물 개수로 한다.
가장 높은 높이의 장애물개수부터 이전 원소들로 누적합을 적용한다.
이제 이 구조는 해당 원소의 위치로 개똥벌래가 지나갈때 부서지는 장애물의 개수를 나타낸다.

- 위에서 자라는 장애물(top), 아래에서 자라는 장애물(down)을 따로 누적합을 구해서 저장
	- top의 누적합은 down과는 다르게 작은 값부터 누적시킨다. (top에 저장된 원소값은 빈공간을 기준으로 저장되어있기때문)
- 모든 높이구간에 대해서 top과 down에 저장된 원소값을 더하면 개똥벌래가 해당높이구간에서 부수고 지나가는 장애물의 개수가 된다.
```

### CODE (이분탐색)

```go
package main

import (
	"bufio"
	"fmt"
	"os"
	"sort"
)

type IO struct {
	reader *bufio.Reader
	writer *bufio.Writer
}
type Blocks struct {
	top  []int
	down []int
}
type Res struct {
	min int
	res int
}

var N, H int

func input(io *IO) *Blocks {
	var tmp int
	blocks := &Blocks{}
	fmt.Fscanf(io.reader, "%d %d", &N, &H)
	for i := 1; i <= N; i++ {
		fmt.Fscan(io.reader, &tmp)
		if i%2 == 0 {
			blocks.top = append(blocks.top, tmp)
		} else {
			blocks.down = append(blocks.down, tmp)
		}
	}
	return blocks
}

func binarySearch(arr []int, t int) int {
	l, r := 0, len(arr)-1
	for l <= r {
		m := l + (r-l)/2
		if arr[m] >= t {
			r = m - 1
		} else {
			l = m + 1
		}
	}
	return l
}

func countBlocking(arr []int, i int) int {
	idx := binarySearch(arr, i)
	if idx != -1 {
		return N/2 - idx
	}
	return 0
}

func solve(blocks *Blocks) *Res {
	min, res := 200001, 1

	sort.Slice(blocks.top, func(i, j int) bool {
		return blocks.top[i] < blocks.top[j]
	})
	sort.Slice(blocks.down, func(i, j int) bool {
		return blocks.down[i] < blocks.down[j]
	})

	for i := 1; i <= H; i++ {
		var cnt int
		cnt += countBlocking(blocks.down, i)
		cnt += countBlocking(blocks.top, H-i+1)
		if min > cnt {
			min = cnt
			res = 1
		} else if min == cnt {
			res++
		}
	}
	return &Res{min, res}
}

func main() {
	f, _ := os.Open("./3020.txt")
	defer f.Close()
	io := &IO{bufio.NewReader(f), bufio.NewWriter(os.Stdout)}
	defer io.writer.Flush()
	blocks := input(io)
	res := solve(blocks)
	fmt.Fprintf(io.writer, "%d %d", res.min, res.res)
}

```

### CODE(누적합)

```go
package main

import (
	"bufio"
	"fmt"
	"os"
	"strconv"
)

var (
	reader *bufio.Scanner
	writer = bufio.NewWriter(os.Stdout)
	N, H   int
)

type Obst struct {
	top  [500001]int
	down [500001]int
}

func setup() *Obst {
	N, H = readInt(), readInt()
	obst := &Obst{}
	for i := 1; i <= N; i++ {
		tmp := readInt()
		if i%2 == 0 {
			obst.top[H-tmp+1] += 1
		} else {
			obst.down[tmp] += 1
		}
	}

	for j := H - 1; j >= 1; j-- {
		obst.down[j] += obst.down[j+1]
	}
	return obst
}

func solve(obst *Obst) {
	min, cnt := 200001, 0
	for i := 1; i <= H; i++ {
		obst.top[i] += obst.top[i-1]
		res := obst.down[i] + obst.top[i]
		if min > res {
			min = res
			cnt = 1
		} else if min == res {
			cnt++
		}
	}
	fmt.Fprint(writer, min, cnt)
}

func main() {
	defer writer.Flush()
	f, _ := os.Open("./3020.txt")
	defer f.Close()

	reader = bufio.NewScanner(f)
	reader.Split(bufio.ScanWords)

	obst := setup()
	solve(obst)
}

func parseInt(s string) int {
	n, _ := strconv.Atoi(s)
	return n
}

func readInt() int {
	reader.Scan()
	return parseInt(reader.Text())
}

```