### PR TITLE
BOJ/6593/상범빌딩/4732KB/8ms

### DIFF
--- a/GO/6593/6593.go
+++ b/GO/6593/6593.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+type IO struct {
+	reader *bufio.Reader
+	writer *bufio.Writer
+}
+
+var (
+	io      = &IO{bufio.NewReader(os.Stdin), bufio.NewWriter(os.Stdout)}
+	L, R, C int
+	dir     [6][3]int = [6][3]int{
+		{0, 0, 1}, {0, 0, -1}, {0, 1, 0}, {0, -1, 0}, {-1, 0, 0}, {1, 0, 0},
+	} //동,서,남,북,상,하
+)
+
+const (
+	CUBESIZE int = 31
+)
+
+func BFS(building *[CUBESIZE][CUBESIZE][CUBESIZE]rune, queue [][4]int) (int, bool) {
+	var visited [CUBESIZE][CUBESIZE][CUBESIZE]int
+	min := 2147000000
+	isExited := false
+	for len(queue) > 0 {
+		el := queue[0]
+		queue = queue[1:]
+		nCnt := el[3] + 1
+		for i := 0; i < 6; i++ {
+			nz := el[0] + dir[i][0]
+			ny := el[1] + dir[i][1]
+			nx := el[2] + dir[i][2]
+
+			if nz >= 1 && nz <= L && ny >= 1 && ny <= R &&
+				nx >= 1 && nx <= C && visited[nz][ny][nx] == 0 {
+				if building[nz][ny][nx] == '.' {
+					visited[nz][ny][nx] = 1
+					queue = append(queue, [4]int{nz, ny, nx, nCnt})
+				} else if building[nz][ny][nx] == 'E' {
+					if min > nCnt {
+						min = nCnt
+						isExited = true
+					}
+				}
+			}
+		}
+	}
+	return min, isExited
+}
+
+func Input(building *[CUBESIZE][CUBESIZE][CUBESIZE]rune) [][4]int {
+	queue := make([][4]int, 0, 10)
+	var str string
+	for i := 1; i <= L; i++ {
+		for j := 1; j <= R; j++ {
+			fmt.Fscan(io.reader, &str)
+			for k, c := range str {
+				(*building)[i][j][k+1] = c
+				if str[k] == 'S' {
+					queue = append(queue, [4]int{i, j, k + 1, 0})
+				}
+			}
+		}
+	}
+	return queue
+}
+
+func Solve() {
+
+	for {
+		fmt.Fscan(io.reader, &L, &R, &C)
+		if L == 0 && R == 0 && C == 0 {
+			break
+		}
+		var building [CUBESIZE][CUBESIZE][CUBESIZE]rune
+		queue := Input(&building)
+		res, isExited := BFS(&building, queue)
+		if isExited {
+			fmt.Fprintf(io.writer, "Escaped in %d minute(s).\n", res)
+		} else {
+			fmt.Fprintln(io.writer, "Trapped!")
+		}
+	}
+}
+
+func main() {
+	f, _ := os.Open("./6593.txt")
+	io.reader = bufio.NewReader(f)
+	defer f.Close()
+	defer io.writer.Flush()
+	Solve()
+}
+
+/*
+슬라이스는 내부적으로 포인터, 길이, 용량을 포함하는 구조
+슬라이스를 함수의 매개변수로 전달하면 실제로는 메타데이터(포인터, 길이, 용량)을 복사하여 전달
+(데이터 자체를 복사하는 것이아닌, 데이터를 참조하는 포인터만 복사) => 함수내에서 슬라이스의 내용수정가능
+슬라이스에 요소를 추가할 때, 내부배열의 용량이 초과된다면 새로운 배열을 생성하고 요소를 복사한다.
+이 경우 원래 슬라이스(매개변수로 전달된 슬라이스의 원본)는 더 이상 새로운 슬라이스를 참조하지않으므로
+따라서 원래 슬라이스를 업데이트할려면 포인터로 전달해야한다.
+여기서 Input으로 넘겨줄때 'S'는 한개이므로 값으로 전달해도 괜찮다.
+*/


### PR DESCRIPTION
(https://www.acmicpc.net/problem/6593)

### 문제설명

- 각 변의 길이가 1인 정육면체로 이루어진 건물이 있다.
- 각 칸에서 인접한 6개의 칸 즉, 동서남북상하로만 이동이 가능하다.
- 각 칸은 금으로 막혀있어 지나갈 수 없거나 길이 있어 지나갈 수 있다.
- 각 칸을 이동하는데 걸리는 시간은 1분이다.
- S → E로 가는데 걸리는 최단시간은 ?
- 만약 S→E로 갈 수있다면 시간을 출력, 갈 수 없다면 Trapped!를 출럭

### 문제조건

- 건물의 총 층 수 L(1 ≤ L ≤ 30), R
- 각 층의 행과 열의 개수(1 ≤ R ≤ 30)과 C(1 ≤ C ≤ 30)
- 시간제한: 1s, 메모리제한:128MB

### 문제풀이

- 건물을 나타내는 building슬라이스의 자료형을 int로 하고 각 원소를 const로 나타내어 진행
    
<img width="160" alt="image" src="https://github.com/user-attachments/assets/142afcef-015c-494a-b1c2-b4c1a55268cb">
    
- building슬라이스의 자료형을 rune여 진행한 것의 시간을 비교해보았는데
    
  
<img width="156" alt="image" src="https://github.com/user-attachments/assets/72e5f46e-49b2-4665-9815-9d6a0cc4726d">

- 메모리 면에서만 근소한 차이가 있었다.

```
building 을 rune슬라이스로 다룬것을 위주로 설명하자면

building의 원소들에 대한 값을 입력받고 ‘S’인경우는 queue에 먼저 삽입해둔다.

queue에 들어가는 값은 (층, 행, 열, 걸린시간)

BFS를 통해 6방향(상,하,동,서,남,북)에 대해 탐색

‘E’가 나온다면 이전까지의 최소시간과 비교해 갱신한다.
```

- Input에 queue를 넘겨줄때 값으로 넘겨준다면 문제발생

```
배열이 값타입이라면 슬라이스는 참조타입
슬라이스는 내부적으로 포인터, 길이, 용량을 포함하는 구조
슬라이스를 함수의 매개변수로 전달하면 실제로는 메타데이터(포인터, 길이, 용량)을 복사하여 전달
(데이터 자체를 복사하는 것이아닌, 데이터를 참조하는 포인터만 복사) => 함수내에서 외부슬라이스의 내용수정가능
하지만 이때 용량이 변경되는 작업을 수행하게 된다면 
외부슬라이스와의 참조가 끊기고 새로운 슬라이스가 생성된다.
```

- 따라서 포인터형으로 넘겨주어 append를 할때도 참조가 유지되도록 한다.

### CODE

```
package main

import (
	"bufio"
	"fmt"
	"os"
)

type IO struct {
	reader *bufio.Reader
	writer *bufio.Writer
}

var (
	io      = &IO{bufio.NewReader(os.Stdin), bufio.NewWriter(os.Stdout)}
	L, R, C int
	dir     [6][3]int = [6][3]int{
		{0, 0, 1}, {0, 0, -1}, {0, 1, 0}, {0, -1, 0}, {-1, 0, 0}, {1, 0, 0},
	} //동,서,남,북,상,하
)

const (
	CUBESIZE int = 31
)

func BFS(building *[CUBESIZE][CUBESIZE][CUBESIZE]rune, queue [][]int) (int, bool) {
	var visited [CUBESIZE][CUBESIZE][CUBESIZE]int
	min := 2147000000
	isExited := false
	for len(queue) > 0 {
		el := queue[0]
		queue = queue[1:]
		nCnt := el[3] + 1
		for i := 0; i < 6; i++ {
			nz := el[0] + dir[i][0]
			ny := el[1] + dir[i][1]
			nx := el[2] + dir[i][2]

			if nz >= 1 && nz <= L && ny >= 1 && ny <= R &&
				nx >= 1 && nx <= C && visited[nz][ny][nx] == 0 {
				if building[nz][ny][nx] == '.' {
					visited[nz][ny][nx] = 1
					queue = append(queue, []int{nz, ny, nx, nCnt})
				} else if building[nz][ny][nx] == 'E' {
					if min > nCnt {
						min = nCnt
						isExited = true
					}
				}
			}
		}
	}
	return min, isExited
}

func Input(building *[CUBESIZE][CUBESIZE][CUBESIZE]rune, queue *[][]int) {
	var str string
	for i := 1; i <= L; i++ {
		for j := 1; j <= R; j++ {
			fmt.Fscan(io.reader, &str)
			for k, c := range str {
				(*building)[i][j][k+1] = c
				if str[k] == 'S' {
					*queue = append(*queue, []int{i, j, k + 1, 0})
				}
			}
		}
	}
}

func Solve() {

	for {
		fmt.Fscan(io.reader, &L, &R, &C)
		if L == 0 && R == 0 && C == 0 {
			break
		}
		var building [CUBESIZE][CUBESIZE][CUBESIZE]rune
		queue := make([][]int, 0, 10)
		Input(&building, &queue)
		res, isExited := BFS(&building, queue)
		if isExited {
			fmt.Fprintf(io.writer, "Escaped in %d minute(s).\n", res)
		} else {
			fmt.Fprintln(io.writer, "Trapped!")
		}
	}
}

func main() {
	// f, _ := os.Open("./6593.txt")
	// io.reader = bufio.NewReader(f)
	// defer f.Close()
	defer io.writer.Flush()
	Solve()
}
```

- 셸환경에서 아스키코드값 출력하는법

```
$ prinf "%d\n" "'#"
35
```