### PR TITLE
BOJ/10166/관중석/45828KB/248ms

### DIFF
--- a/GO/10166/10166.go
+++ b/GO/10166/10166.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+var (
+	reader = bufio.NewReader(os.Stdin)
+	writer = bufio.NewWriter(os.Stdout)
+	stage  [2001][2001]int
+)
+
+func gcd(i, j int) int {
+	for j%i != 0 {
+		j, i = i, j%i
+	}
+	return i
+}
+
+/*
+func gcd(a,b int)int{ (a>b)
+	if b==0{
+		return a
+	}
+	return gcd(b,a%b)
+}
+*/
+
+func solve() {
+	var d1, d2, res int
+	fmt.Fscan(reader, &d1, &d2)
+
+	for i := d1; i <= d2; i++ {
+		for j := 1; j <= i; j++ {
+			t := gcd(j, i)
+			num, deno := j/t, i/t
+			if stage[num][deno] == 0 {
+				stage[num][deno] = 1
+				res++
+			}
+		}
+	}
+	fmt.Fprintln(writer, res)
+}
+
+func main() {
+	defer writer.Flush()
+
+	solve()
+}


### PR DESCRIPTION
(https://www.acmicpc.net/problem/10166)

### 문제설명

반지름이 자연수인 동심원이 무대 중앙 공연장을 중심으로 배치 되어있다.

무대에서 정확히 북쪽에는 모든 원들에 좌석이 있으며, 하나의 원위에 있는 좌석들은 동일한 간격으로 배치되어있다.

반지름이 D1인 좌석부터 D2인 좌석을 이용한다하였을때, 앞 동심원들의 좌석에 가려지지않는 좌석을 배정하려고한다.

이때 배정할수있는 좌석의 수는?

### 문제조건

첫 줄에 원의 반지름 D1과 D2가 양의 정수로 주어진다. 단, 1 ≤ D1 ≤ D2 ≤ 2,000이다.

시간제한:1s, 메모리제한:64MB

### 문제풀이

- 원은 360도 이므로 각 좌석을 360개크기의 배열로 관리하려고 했으나 조건이 2000이므로 실수로 떨어지기 때문에 애매하다.
- 따라서 분자와 분모를 [2001][2001]크기의 이차원 배열로 관리

```go
0       1/3.      2/3.     1
0. ...  2/6.  ... 3/6. ... 1

1/3과 2/6은 같으므로 중복(앞좌석에 가려짐)을 제거할 수 있다.

2/6을 1/3으로 나타내기위해서는 2와 6의 최대공약수인 2로 나누어야하는데
이를 구하기위해서 gcd함수(유클리드호제법)를 이용.
```

### CODE

```go
package main

import (
	"bufio"
	"fmt"
	"os"
)

var (
	reader = bufio.NewReader(os.Stdin)
	writer = bufio.NewWriter(os.Stdout)
	stage  [2001][2001]int
)

func gcd(i, j int) int {
	for j%i != 0 {
		j, i = i, j%i
	}
	return i
}

/*
func gcd(a,b int)int{ (a>b)
	if b==0{
		return a
	}
	return gcd(b,a%b)
}
*/

func solve() {
	var d1, d2, res int
	fmt.Fscan(reader, &d1, &d2)

	for i := d1; i <= d2; i++ {
		for j := 1; j <= i; j++ {
			t := gcd(j, i)
			num, deno := j/t, i/t
			if stage[num][deno] == 0 {
				stage[num][deno] = 1
				res++
			}
		}
	}
	fmt.Fprintln(writer, res)
}

func main() {
	defer writer.Flush()

	solve()
}

```