### PR TITLE
BOJ/1052/물병/876KB/4ms

### DIFF
--- a/GO/1052/1052.go
+++ b/GO/1052/1052.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"math"
+	"os"
+	"strings"
+)
+
+var (
+	reader = bufio.NewReader(os.Stdin)
+	writer = bufio.NewWriter(os.Stdout)
+)
+
+func solve(n, k int) {
+	res, base := 1, 2
+	str := fmt.Sprintf("%b", n)
+
+	if strings.Count(str, "1") <= k {
+		fmt.Fprintln(writer, 0)
+		return
+	}
+
+	binaryN := make([]byte, len(str))
+	for i := range str {
+		binaryN[i] = str[i]
+	}
+
+	for i := range binaryN {
+		if binaryN[len(binaryN)-i-1] == 48 {
+			if i == 0 {
+				res += 1
+			} else {
+				res += int(math.Pow(float64(base), float64(i)))
+			}
+		} else { // binaryN[len(binaryN)-i-1] == 49
+			cnt := 0
+			for j := 0; j <= len(binaryN)-i-1; j++ {
+				if cnt > k {
+					break
+				}
+				if binaryN[j] == 49 {
+					cnt++
+				}
+			}
+			if cnt <= k {
+				break
+			}
+		}
+	}
+	fmt.Fprintln(writer, res)
+}
+
+func main() {
+	var n, k int
+	defer writer.Flush()
+	// f, _ := os.Open("./1052.txt")
+	// defer f.Close()
+	// reader = bufio.NewReader(f)
+
+	fmt.Fscan(reader, &n, &k)
+	solve(n, k)
+}


### PR DESCRIPTION
https://www.acmicpc.net/problem/1052
### 문제 설명

- N개의 물병(1L가 들어있는)이 있을 때, 다음과 같은 방식으로 재분배하여 K개를 넘지않는 비어있지 않은 물병을 만들려고한다.

```go
먼저 같은 양의 물이 들어있는 물병 두 개를 고른다. 
그 다음에 한 개의 물병에 다른 한 쪽에 있는 물을 모두 붓는다. 이 방법을 필요한 만큼 계속 한다.
```

- 이러한 제약으로인해 N개로 K를 넘지않는 비어있지 않은 물병을 만드는 것이 불가능할 수도 있다.
- 따라서 상점에서 1L가 들어있는 물병을 살수도있다.
- 상점에서 사야하는 물병의 최솟값을 구하시오.

### 문제 조건

- N은 107보다 작거나 같은 자연수이고, K는 1,000보다 작거나 같은 자연수
- 시간제한 : 1s, 메모리제한: 512MB

### 문제 풀이

- 주어진 N을 이진법으로 나타낸다.
- 높은자리수부터 1을 세었을때의 개수가 만들어지는 물병의 개수

```go
13 => 1101(2)

물병을 2개이하로 만들기위해서는
2를 더한다. 1111(2) 
1을 더한다. 10000(2)

따라서 3개의 물병을 상점에서 구매한다면 2개이하의 물병을 만들 수 있다.
```

- 2진법수의 자리수가 0일 경우
    - 해당 자리수의 값을 더한다.
- 2진법수의 자리수가 1일 경우
    - 1은 물병을 의미하므로
    - 최고자리수부터 해당 자리수까지의 1을 포함해 k이하의 물병이 존재하는지 확인
    - k이하일 경우 현재까지 더한 자리수값이 상점에서 구매해야하는 물병의 수

### CODE

```go
package main

import (
	"bufio"
	"fmt"
	"math"
	"os"
)

var (
	reader = bufio.NewReader(os.Stdin)
	writer = bufio.NewWriter(os.Stdout)
)

func solve(n, k int) {
	res, base, tmp := 1, 2, 0
	str := fmt.Sprintf("%b", n)
	binaryN := make([]byte, len(str))
	for i := range str {
		if str[i] == '1' {
			tmp++
		}
		binaryN[i] = str[i]
	}
	if tmp <= k { // 물병을 상점에서 구매하기전 현재 물병개수 확인
		fmt.Fprintln(writer, 0)
		return
	}

	for i := range binaryN {
		if binaryN[len(binaryN)-i-1] == 48 {
			if i == 0 {
				res += 1
			} else {
				res += int(math.Pow(float64(base), float64(i)))
			}
		} else { // binaryN[len(binaryN)-i-1] == 49
			cnt := 0
			for j := 0; j <= len(binaryN)-i-1; j++ {
				if cnt > k {
					break
				}
				if binaryN[j] == 49 {
					cnt++
				}
			}
			if cnt <= k {
				break
			}
		}
	}
	fmt.Fprintln(writer, res)
}

func main() {
	var n, k int
	defer writer.Flush()
	
	fmt.Fscan(reader, &n, &k)
	solve(n, k)
}

```