### PR TITLE
BOJ/11497/통나무 건너뛰기/3284KB/56ms

### DIFF
--- a/GO/11497/11497.go
+++ b/GO/11497/11497.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"sort"
+	"strconv"
+)
+
+var (
+	scanner = bufio.NewScanner(os.Stdin)
+	writer  = bufio.NewWriter(os.Stdout)
+)
+
+func input() []int {
+	N := scanInt()
+	arr := make([]int, N)
+	for i := 0; i < N; i++ {
+		num := scanInt()
+		arr[i] = num
+	}
+	sort.Slice(arr, func(i, j int) bool {
+		return arr[i] < arr[j]
+	})
+	return arr
+}
+
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+func abs(a, b int) int {
+	if a > b {
+		return a - b
+	}
+	return b - a
+}
+
+func solve() {
+	N := scanInt()
+	for i := 0; i < N; i++ {
+		arr := input()
+		res := 0
+		num1 := arr[0]
+		num2 := arr[1]
+		for j := 2; j < len(arr); j++ {
+			if j%2 == 0 {
+				res = max(abs(num1, arr[j]), res)
+				num1 = arr[j]
+			} else {
+				res = max(abs(num2, arr[j]), res)
+				num2 = arr[j]
+			}
+		}
+		fmt.Fprintln(writer, res)
+	}
+}
+
+func main() {
+	defer writer.Flush()
+
+	f, _ := os.Open("./11497.txt")
+	defer f.Close()
+	scanner = bufio.NewScanner(f)
+	scanner.Split(bufio.ScanWords) //단어 단위
+
+	solve()
+}
+
+func scanInt() int {
+	scanner.Scan()
+	v, _ := strconv.Atoi(scanner.Text())
+	return int(v)
+}


### PR DESCRIPTION
https://www.acmicpc.net/problem/11497

### 문제 설명

- 통나무 건너뛰기의 난이도는 **인접한 두 통나무의 높이차 중 가장 큰 차이**로 결정된다.
- 통나무는 둥글게 이어져있다.
- 예를들어, [2,4,5,7,9]의 통나무 높이가 주어진다면
    - 4-2=2
    - 5-4=1
    - …
    - 9-2=7
    - 통나무는 둥글게 이어져있으므로 처음 원소와 마지막원소의 차이도 난이도에 반영한다.
- 이때 통나무를 배치하여 만들수있는 최소난이도를 구하시오.

### 문제 조건

- 통나무의 개수를 나타내는 정수 N(5 ≤ N ≤ 10,000)
- 통나무의 높이를 나타내는 정수 Li가 주어진다. (1 ≤ Li ≤ 100,000)
- 시간제한:1s, 메모리제한:256MB

### 문제 풀이

- 인접한 통나무끼리의 차이 중 가장 큰 값이 해당 통나무 배치에서의 **난이도.**
- 가장 작은 난이도를 구하기위해서는 인접한 통나무끼리의 차이가 작아야한다.
- 이렇게 만들려면
    - 통나무 배열을 오름차순으로 정렬한 후
    - 0,2,4… 마지막원소
    - 마지막원소-1, …1
    - 까지 차례대로 넣어주면 난이도가 가장 작은 통나무배치가 된다.
    - 원소의 개수가 홀수, 짝수인경우 다음과 같이 마지막 원소를 다르게 지정
    
    ```go
    if N%2 == 1 {
    		s = N - 2
    	} else {
    		s = N - 1
    	}
    ```
    

### CODE (148ms)

```go
package main

import (
	"bufio"
	"fmt"
	"math"
	"os"
	"sort"
)

var (
	reader = bufio.NewReader(os.Stdin)
	writer = bufio.NewWriter(os.Stdout)
)

func makeLogs(tmp []int) []int {
	var s int
	N := len(tmp)
	sort.Slice(tmp, func(i, j int) bool {
		return tmp[i] < tmp[j]
	})

	var arr []int
	for i := 0; i < N; i += 2 {
		arr = append(arr, tmp[i])
	}
	if N%2 == 1 {
		s = N - 2
	} else {
		s = N - 1
	}
	for i := s; i >= 0; i -= 2 {
		arr = append(arr, tmp[i])
	}
	return arr
}

func input() []int {
	var N, num int
	fmt.Fscan(reader, &N)
	tmp := make([]int, N)
	for i := 0; i < N; i++ {
		fmt.Fscan(reader, &num)
		tmp[i] = num
	}
	return makeLogs(tmp)
}

func solve() {
	var N int
	fmt.Fscan(reader, &N)

	for i := 0; i < N; i++ {
		res := 0
		arr := input()

		for j := 0; j < len(arr)-1; j++ {
			diff := int(math.Abs(float64(arr[j] - arr[j+1])))
			if diff > res {
				res = diff
			}
		}
		diff := int(math.Abs(float64(arr[0] - arr[len(arr)-1])))
		if diff > res {
			res = diff
		}
		fmt.Fprintln(writer, res)
	}
}

func main() {
	defer writer.Flush()

	// f, _ := os.Open("./11497.txt")
	// defer f.Close()
	// reader = bufio.NewReader(f)
	solve()
}

```

### CODE2 (56ms)

```go
package main

import (
	"bufio"
	"fmt"
	"os"
	"sort"
	"strconv"
)

var (
	scanner = bufio.NewScanner(os.Stdin)
	writer  = bufio.NewWriter(os.Stdout)
)

func input() []int {
	N := scanInt()
	arr := make([]int, N)
	for i := 0; i < N; i++ {
		num := scanInt()
		arr[i] = num
	}
	sort.Slice(arr, func(i, j int) bool {
		return arr[i] < arr[j]
	})
	return arr
}

func max(a, b int) int {
	if a > b {
		return a
	}
	return b
}
func abs(a, b int) int {
	if a > b {
		return a - b
	}
	return b - a
}

func solve() {
	N := scanInt()
	for i := 0; i < N; i++ {
		arr := input()

		num1 := arr[0]
		num2 := arr[1]
		for j := 2; j < len(arr); j++ {
			if j%2 == 0 {
				res = max(abs(num1, arr[j]), res)
				num1 = arr[j]
			} else {
				res = max(abs(num2, arr[j]), res)
				num2 = arr[j]
			}
		}
		fmt.Fprintln(writer, res)
	}
}

func main() {
	defer writer.Flush()
	scanner.Split(bufio.ScanWords) //단어 단위

	solve()
}

func scanInt() int {
	scanner.Scan()
	v, _ := strconv.Atoi(scanner.Text())
	return int(v)
}

```

### 성능개선

- makeLogs를 통해 슬라이스를 새로 생성하는 것이 아닌 원래 슬라이스에서 계산
    
    ```go
    예를들어
    
    1 2 5 7 8 9 가 있을 경우
    makeLogs를 통해
    1 5 8 9 7 2 를 만들어 난이도를 계산했지만 이 과정은 생략가능.
    
    기존 정렬된 슬라이스에서
    하나의 난이도 변수를 
    짝수는 짝수끼리 홀수는 홀수끼리만 비교하여 난이도를 갱신하면 makeLogs를 호출할 필요 없다.
    ```
    
- scanner는 작은 버퍼사이즈를 가지고있기에 작은 입력에 reader보다 더 좋은 성능을 보인다.